### PR TITLE
🎨 Palette: Add animated spinner to working indicator

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-02-05 – Accessible Labels for Custom Icon Buttons
 **Learning:** For custom icon buttons (e.g., ellipses/dots), implementing the visual rendering in the `draw_bg` shader using SDFs while using the `text` property and `draw_text: { color: #0000 }` provides a descriptive, hidden accessibility label without breaking the visual design.
 **Action:** Use this pattern to replace opaque symbols or empty strings in all icon-only controls.
+
+## 2026-02-24 – Animated Status Spinner
+**Learning:** Using a rotating sequence of Unicode characters (e.g., ◐, ◓, ◑, ◒) in a `Label` text provides a lightweight, accessible, and high-impact way to indicate an active "Working" state without custom shaders. It integrates seamlessly with Makepad's frame-driven event loop.
+**Action:** When adding long-running async states, implement this text-based spinner in the main header or status bar to provide immediate visual feedback.

--- a/openpad-app/src/app.rs
+++ b/openpad-app/src/app.rs
@@ -210,7 +210,7 @@ script_mod! {
                                             flow: Right
                                             align: Align{ y: 0.5 }
                                             visible: false
-                                            Label { text: "Working..." }
+                                            work_label := Label { text: "Working..." }
                                         }
                                         status_dot := StatusDot {}
                                         status_label := Label { text: "Connected" }
@@ -363,6 +363,8 @@ pub struct App {
     connected_once: bool,
     #[rust]
     providers_loaded_once: bool,
+    #[rust]
+    frame_count: u64,
 }
 
 impl App {
@@ -573,6 +575,12 @@ impl AppMain for App {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
         if self.state.is_working {
             if let Event::NextFrame(_) = event {
+                self.frame_count += 1;
+                let frames = ["◐", "◓", "◑", "◒", "◔", "◕"];
+                let frame = frames[(self.frame_count as usize / 10) % frames.len()];
+                self.ui
+                    .label(cx, &[id!(work_label)])
+                    .set_text(cx, &format!("{} Working...", frame));
                 self.ui.view(cx, &[id!(work_indicator)]).redraw(cx);
             }
             cx.new_next_frame();

--- a/openpad-app/src/state/reducer.rs
+++ b/openpad-app/src/state/reducer.rs
@@ -149,12 +149,7 @@ pub fn reduce_app_state(state: &mut AppState, action: &AppAction) -> Vec<StateEf
             state.providers = providers_response.providers.clone();
 
             let mut provider_labels = vec!["Default".to_string()];
-            provider_labels.extend(
-                state
-                    .providers
-                    .iter()
-                    .map(|p| p.name.clone()),
-            );
+            provider_labels.extend(state.providers.iter().map(|p| p.name.clone()));
             state.provider_labels = provider_labels;
             state.selected_provider_idx = 0;
             state.update_model_list_for_provider();

--- a/openpad-app/src/ui/state_updates.rs
+++ b/openpad-app/src/ui/state_updates.rs
@@ -30,6 +30,9 @@ pub fn set_status_error(ui: &WidgetRef, cx: &mut Cx, error: &str) {
 
 pub fn update_work_indicator(ui: &WidgetRef, cx: &mut Cx, working: bool) {
     ui.view(cx, &[id!(work_indicator)]).set_visible(cx, working);
+    if !working {
+        ui.label(cx, &[id!(work_label)]).set_text(cx, "Working...");
+    }
 }
 
 /// Updates the session title label with appropriate styling

--- a/openpad-widgets/src/settings_dialog.rs
+++ b/openpad-widgets/src/settings_dialog.rs
@@ -238,11 +238,7 @@ impl SettingsDialog {
     pub fn set_providers(&mut self, cx: &mut Cx, providers: Vec<Provider>) {
         self.providers = providers;
 
-        let items: Vec<String> = self
-            .providers
-            .iter()
-            .map(|p| p.name.clone())
-            .collect();
+        let items: Vec<String> = self.providers.iter().map(|p| p.name.clone()).collect();
         self.view
             .up_drop_down(cx, &[id!(content), id!(provider_dropdown)])
             .set_labels(cx, items);


### PR DESCRIPTION
This PR introduces an animated spinner to the "Working..." status indicator in the application header. 

By using a rotating sequence of Unicode characters (◐, ◓, ◑, ◒, ◔, ◕) that updates every few frames, it provides users with immediate and continuous visual feedback that a background operation (like AI generation or summarization) is actively progressing.

Key changes:
- Extended the `App` struct with a `frame_count` to drive the animation.
- Updated the Makepad DSL to uniquely identify the working status label.
- Added animation logic to the main event loop's `NextFrame` handler.
- Included a cleanup step to reset the label text when the working state ends.
- Standardized code formatting across affected files.

---
*PR created automatically by Jules for task [13660619175098637696](https://jules.google.com/task/13660619175098637696) started by @wheregmis*