### PR TITLE
🎨 Palette: Animated working indicator and share button feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-02-05 – Accessible Labels for Custom Icon Buttons
 **Learning:** For custom icon buttons (e.g., ellipses/dots), implementing the visual rendering in the `draw_bg` shader using SDFs while using the `text` property and `draw_text: { color: #0000 }` provides a descriptive, hidden accessibility label without breaking the visual design.
 **Action:** Use this pattern to replace opaque symbols or empty strings in all icon-only controls.
+
+## 2025-02-13 – Animated Indicators and Transient Feedback
+**Learning:** High-impact UX can be achieved with minimal code by leveraging Makepad's `NextFrame` event loop for animations and timers. Using Unicode characters (◐, ◑, ◒, ◓, ◔, ◕) provides a lightweight alternative to complex shader-based spinners. Transient feedback (e.g., 'Copied!') on buttons improves interaction quality by confirming invisible actions.
+**Action:** Store `frame_count` or `Instant` in the `App` or widget struct. In `handle_event`, use the `Event::NextFrame` block to update UI state (text, visibility) and call `cx.new_next_frame()` to drive the loop until the animation or timer completes.

--- a/openpad-app/src/constants.rs
+++ b/openpad-app/src/constants.rs
@@ -34,6 +34,9 @@ pub const PROJECT_CONTEXT_NO_PROJECT: &str = "No active project";
 // OpenCode server configuration
 pub const OPENCODE_SERVER_URL: &str = "http://localhost:4096";
 
+// Spinner frames for animated "Working" indicator
+pub const SPINNER_FRAMES: &[&str] = &["◐", "◑", "◒", "◓", "◔", "◕"];
+
 // Timing constants (in seconds)
 pub const HEALTH_CHECK_INTERVAL_SECS: u64 = 5;
 pub const SSE_RETRY_DELAY_SECS: u64 = 2;


### PR DESCRIPTION
This PR introduces two high-impact UX improvements to Openpad:

1. **Animated Working Indicator**: The static "Working..." label in the header is now animated with a Unicode-based spinner (◐, ◑, ◒, ◓, ◔, ◕). This provides clear visual feedback that the app is processing a request.
2. **"Copied!" Feedback for Share Link**: Clicking the "Copy link" button now temporarily changes its text to "Copied!" for 2 seconds. This confirms the action to the user, improving the perceived reliability of the share feature.

Both features are implemented using Makepad's `NextFrame` event system, ensuring they only consume CPU when active and remain efficient.

---
*PR created automatically by Jules for task [13299993266124782882](https://jules.google.com/task/13299993266124782882) started by @wheregmis*