### PR TITLE
Sync OpenAPI spec and update protocol client with deleteMessage

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2630,6 +2630,76 @@
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.message({\n  ...\n})"
           }
         ]
+      },
+      "delete": {
+        "operationId": "session.deleteMessage",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Session ID"
+          },
+          {
+            "in": "path",
+            "name": "messageID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Message ID"
+          }
+        ],
+        "summary": "Delete message",
+        "description": "Permanently delete a specific message (and all of its parts) from a session. This does not revert any file changes that may have been made while processing the message.",
+        "responses": {
+          "200": {
+            "description": "Successfully deleted message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.deleteMessage({\n  ...\n})"
+          }
+        ]
       }
     },
     "/session/{sessionID}/message/{messageID}/part/{partID}": {

--- a/openpad-protocol/src/client.rs
+++ b/openpad-protocol/src/client.rs
@@ -522,6 +522,11 @@ impl OpenCodeClient {
         self.get_json(&endpoint, "get message").await
     }
 
+    pub async fn delete_message(&self, session_id: &str, message_id: &str) -> Result<bool> {
+        let endpoint = format!("/session/{}/message/{}", session_id, message_id);
+        self.delete_bool(&endpoint, "delete message").await
+    }
+
     pub async fn send_prompt_with_options(
         &self,
         session_id: &str,


### PR DESCRIPTION
This change syncs the local `openapi.json` with the latest remote OpenCode specification. It adds the missing `deleteMessage` operation to the `/session/{sessionID}/message/{messageID}` endpoint. Correspondingly, the `openpad-protocol` Rust client is updated with a new `delete_message` method. 

The update to `openapi.json` was performed surgically to avoid reformatting noise and to preserve local-only TUI configuration fields (`KeybindsConfig`, `theme`, etc.) that are not present in the base SDK specification but are used by this application.

All relevant tests in `openpad-protocol`, including the OpenAPI validation suite, have been verified to pass.

---
*PR created automatically by Jules for task [7444984679447847597](https://jules.google.com/task/7444984679447847597) started by @wheregmis*